### PR TITLE
Fixing call to self.tick

### DIFF
--- a/covid19_sir/utils.py
+++ b/covid19_sir/utils.py
@@ -229,7 +229,7 @@ class Propaganda():
         elif self.state == 1:
             if not (self.count % 3):
                 self.count += 1
-                self.tick
+                self.tick()
 
 def build_district(name, model, population_size, building_capacity, unit_capacity,
                    occupacy_rate, contagion_probability):


### PR DESCRIPTION
This change didn't generate any differences when running regression tests but the call to "self.tick" was likely wrong. 