### PR TITLE
Sharing second directory and renaming container to avoid confusion

### DIFF
--- a/run-container.sh
+++ b/run-container.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run -p 8887:8887 --name covid_simulation --mount "type=bind,src=$(pwd),dst=/opt/singnet/covid-simulation" -ti covid-simulation bash
+docker run -p 8887:8887 --name covid_simulation_container --mount "type=bind,src=$(pwd),dst=/opt/singnet/covid-simulation" -v ~/Shared:/home/user/Shared -ti covid-simulation bash


### PR DESCRIPTION
Overdue changes following a slack discussion to mount a second volume to the docker container and rename it so as not to be confused with the image name.