### PR TITLE
Replacing soon to be deprecated random_integers function by randint

### DIFF
--- a/covid19_sir/model/base.py
+++ b/covid19_sir/model/base.py
@@ -18,7 +18,7 @@ def flip_coin(prob):
 
 
 def _random_selection(v):
-    return v[np.random.random_integers(0, len(v) - 1)]
+    return v[np.random.randint(len(v))]
 
 
 def random_selection(v, n=1):


### PR DESCRIPTION
Replacing soon to be deprecated `random_integers` function by `randint`. This generates deprecation warnings while running unit tests.

A slight change was necessary because `random_integers` returns numbers in the **closed** interval _[low, high]_, while `randint` returns numbers in the **half-open** interval _[low, high)_.

Also, set "high" to None (the default), so that numbers are drawn from [0, low).